### PR TITLE
stop nil defaults

### DIFF
--- a/test/ch/connection_test.exs
+++ b/test/ch/connection_test.exs
@@ -292,13 +292,13 @@ defmodule Ch.ConnectionTest do
       Ch.query!(
         conn,
         "insert into test_bool(A, B) format RowBinary",
-        Stream.map([[3, true], [4, false], [5, nil]], fn row ->
+        Stream.map([[3, true], [4, false]], fn row ->
           Ch.RowBinary.encode_row(row, [:i64, :boolean])
         end)
       )
 
       # anything > 0 is `true`, here `2` is `true`
-      Ch.query!(conn, "insert into test_bool(A, B) values (6, 2)")
+      Ch.query!(conn, "insert into test_bool(A, B) values (5, 2)")
 
       assert %{
                rows: [
@@ -306,8 +306,7 @@ defmodule Ch.ConnectionTest do
                  [2, false, 0],
                  [3, true, 3],
                  [4, false, 0],
-                 [5, false, 0],
-                 [6, true, 6]
+                 [5, true, 5]
                ]
              } = Ch.query!(conn, "SELECT *, A * B FROM test_bool ORDER BY A")
     end

--- a/test/support/test.ex
+++ b/test/support/test.ex
@@ -1,37 +1,4 @@
 defmodule Ch.Test do
-  def dump_type(:string), do: "String"
-
-  def dump_type(:u8), do: "UInt8"
-  def dump_type(:u16), do: "UInt16"
-  def dump_type(:u32), do: "UInt32"
-  def dump_type(:u64), do: "UInt64"
-  def dump_type(:u128), do: "UInt128"
-  def dump_type(:u256), do: "UInt256"
-
-  def dump_type(:i8), do: "Int8"
-  def dump_type(:i16), do: "Int16"
-  def dump_type(:i32), do: "Int32"
-  def dump_type(:i64), do: "Int64"
-  def dump_type(:i128), do: "Int128"
-  def dump_type(:i256), do: "Int256"
-
-  def dump_type(:f32), do: "Float32"
-  def dump_type(:f64), do: "Float64"
-
-  def dump_type(:date), do: "Date"
-  def dump_type(:date32), do: "Date32"
-
-  def dump_type(:datetime), do: "DateTime"
-  def dump_type({:datetime, nil}), do: "DateTime"
-  def dump_type({:datetime, timezone}), do: "DateTime('#{timezone}')"
-
-  def dump_type({:datetime64, precision, nil}), do: "DateTime64(#{precision})"
-  def dump_type({:datetime64, precision, timezone}), do: "DateTime64(#{precision}, '#{timezone}')"
-
-  def dump_type({:array, type}), do: "Array(#{dump_type(type)})"
-
-  def dump_type({:nullable, type}), do: "Nullable(#{dump_type(type)})"
-
   # makes an http request to clickhouse bypassing dbconnection
   def sql_exec(sql, opts \\ []) do
     with {:ok, conn} <- Ch.Connection.connect(opts) do


### PR DESCRIPTION
Instead, `RowBinaryWithNamesAndTypes` with a header of `Nullable(...)` types can be used. This way `Repo.insert_all` would behave similarly to other adapters, `nil` -> `db default`.